### PR TITLE
Определение наличия точки в глобальном фильтре

### DIFF
--- a/_core/_framework/CRequest.class.php
+++ b/_core/_framework/CRequest.class.php
@@ -107,10 +107,17 @@ class CRequest {
             "value" => false
         );
         if (CRequest::getString("filter") != "") {
-        	foreach (explode("_", CRequest::getString("filter")) as $filter) {
+        	if (strpos(CRequest::getString("filter"), ".") === false) {
+        		$filter = CUtils::strRight(CRequest::getString("filter"), "=");
         		$params = explode(":", $filter);
         		$result["field"] = $params[0];
         		$result["value"] = $params[1];
+        	} else {
+        		foreach (explode("_", CRequest::getString("filter")) as $filter) {
+        			$params = explode(":", $filter);
+        			$result["field"] = $params[0];
+        			$result["value"] = $params[1];
+        		}
         	}
         }
         return $result;

--- a/_core/_framework/CRequest.class.php
+++ b/_core/_framework/CRequest.class.php
@@ -107,17 +107,10 @@ class CRequest {
             "value" => false
         );
         if (CRequest::getString("filter") != "") {
-        	if (strpos(CRequest::getString("filter"), ".") === false) {
-        		$filter = CUtils::strRight(CRequest::getString("filter"), "=");
+        	foreach (explode("~", CRequest::getString("filter")) as $filter) {
         		$params = explode(":", $filter);
         		$result["field"] = $params[0];
         		$result["value"] = $params[1];
-        	} else {
-        		foreach (explode("_", CRequest::getString("filter")) as $filter) {
-        			$params = explode(":", $filter);
-        			$result["field"] = $params[0];
-        			$result["value"] = $params[1];
-        		}
         	}
         }
         return $result;
@@ -169,14 +162,15 @@ class CRequest {
     }
 
     /**
-     * Получить значение фильтра
-     *
+     * Получить значение фильтра.
+     * В качестве разделителя фильтров используется ~
+     * 
      * @param $name
      * @return null|int
      */
     public static function getFilter($name) {
         $filters = new CArrayList();
-        foreach (explode("_", CRequest::getString("filter")) as $filter) {
+        foreach (explode("~", CRequest::getString("filter")) as $filter) {
             $values = explode(":", $filter);
             if (count($values) > 1) {
                 if ($values[1] != 0) {

--- a/_core/_views/_aspirants_view/index.tpl
+++ b/_core/_views/_aspirants_view/index.tpl
@@ -45,7 +45,7 @@
         	if (isArchive) {
         		query[query.length] = "isArchive=1";
         	}
-        	query[query.length] = "filter=" + filter.join("_");
+        	query[query.length] = "filter=" + filter.join("~");
         	query[query.length] = "action=index";
         	window.location.href = "index.php?" + query.join("&");
         }

--- a/_core/_views/_corriculum/_workplan/workplan/header.tpl
+++ b/_core/_views/_corriculum/_workplan/workplan/header.tpl
@@ -10,7 +10,7 @@
 			{if !$isApprove}
 				{if !is_null($currentPerson)}
 					jQuery("#corriculum_selector").change(function(){
-		                window.location.href=web_root + "_modules/_corriculum/workplans.php?filter=corriculum.id:" + jQuery(this).val() + "_person.id:{$currentPerson}";
+		                window.location.href=web_root + "_modules/_corriculum/workplans.php?filter=corriculum.id:" + jQuery(this).val() + "~person.id:{$currentPerson}";
 		            });
 				{else}
 					jQuery("#corriculum_selector").change(function(){
@@ -19,7 +19,7 @@
 		    	{/if}
 		    	{if !is_null($currentCorriculum)}
 			    	jQuery("#person_selector").change(function(){
-		                window.location.href=web_root + "_modules/_corriculum/workplans.php?filter=person.id:" + jQuery(this).val() + "_corriculum.id:{$currentCorriculum}";
+		                window.location.href=web_root + "_modules/_corriculum/workplans.php?filter=person.id:" + jQuery(this).val() + "~corriculum.id:{$currentCorriculum}";
 		            });
 			    {else}
 				    jQuery("#person_selector").change(function(){
@@ -29,7 +29,7 @@
 		    {else}
 				{if !is_null($currentPerson)}
 					jQuery("#corriculum_selector").change(function(){
-		                window.location.href=web_root + "_modules/_corriculum/workplans.php?isApprove=1&filter=corriculum.id:" + jQuery(this).val() + "_person.id:{$currentPerson}";
+		                window.location.href=web_root + "_modules/_corriculum/workplans.php?isApprove=1&filter=corriculum.id:" + jQuery(this).val() + "~person.id:{$currentPerson}";
 		            });
 				{else}
 					jQuery("#corriculum_selector").change(function(){
@@ -38,7 +38,7 @@
 		    	{/if}
 		    	{if !is_null($currentCorriculum)}
 			    	jQuery("#person_selector").change(function(){
-		                window.location.href=web_root + "_modules/_corriculum/workplans.php?isApprove=1&filter=person.id:" + jQuery(this).val() + "_corriculum.id:{$currentCorriculum}";
+		                window.location.href=web_root + "_modules/_corriculum/workplans.php?isApprove=1&filter=person.id:" + jQuery(this).val() + "~corriculum.id:{$currentCorriculum}";
 		            });
 			    {else}
 				    jQuery("#person_selector").change(function(){

--- a/_core/_views/_diploms/approve.tpl
+++ b/_core/_views/_diploms/approve.tpl
@@ -32,7 +32,7 @@
     		if (isApprove) {
     			query[query.length] = "isApprove=1";
     		}
-    		query[query.length] = "filter=" + filter.join("_");
+    		query[query.length] = "filter=" + filter.join("~");
     		query[query.length] = "action=index";
     		window.location.href = "index.php?" + query.join("&");
     	}

--- a/_core/_views/_diploms/diplom_preview/index.tpl
+++ b/_core/_views/_diploms/diplom_preview/index.tpl
@@ -52,7 +52,7 @@
     		if (isArchive) {
     			query[query.length] = "isArchive=1";
     		}
-    		query[query.length] = "filter=" + filter.join("_");
+    		query[query.length] = "filter=" + filter.join("~");
     		query[query.length] = "action=index";
     		window.location.href = "preview.php?" + query.join("&");
     	}

--- a/_core/_views/_diploms/index.tpl
+++ b/_core/_views/_diploms/index.tpl
@@ -51,7 +51,7 @@
     		if (isArchive) {
     			query[query.length] = "isArchive=1";
     		}
-    		query[query.length] = "filter=" + filter.join("_");
+    		query[query.length] = "filter=" + filter.join("~");
     		query[query.length] = "action=index";
     		window.location.href = "index.php?" + query.join("&");
     	}

--- a/_core/_views/_library/view.tpl
+++ b/_core/_views/_library/view.tpl
@@ -20,7 +20,7 @@
 	       		}
 	       	});
 	       	query[query.length] = "action=view";
-	       	query[query.length] = "filter=" + filter.join("_");
+	       	query[query.length] = "filter=" + filter.join("~");
 	       	window.location.href = "index.php?" + query.join("&");
 	       }
 	   	$("#user_id").change(function(){

--- a/_core/_views/_pract_bases/index.tpl
+++ b/_core/_views/_pract_bases/index.tpl
@@ -39,7 +39,7 @@
         			filter[filter.length] = key + ":" + value;	
     			}
     		});
-    		query[query.length] = "filter=" + filter.join("_");
+    		query[query.length] = "filter=" + filter.join("~");
     		query[query.length] = "action=index";
     		window.location.href = "index.php?" + query.join("&");
     	}

--- a/_core/_views/_question_answ/index.tpl
+++ b/_core/_views/_question_answ/index.tpl
@@ -45,7 +45,7 @@
         	if (isArchive) {
         		query[query.length] = "isArchive=1";
         	}
-        	query[query.length] = "filter=" + filter.join("_");
+        	query[query.length] = "filter=" + filter.join("~");
         	query[query.length] = "action=index";
         	window.location.href = "index.php?" + query.join("&");
         }


### PR DESCRIPTION
Использование разделителя _ в фильтре с двумя и более полями приводит
к неправильному срабатыванию фильтра для полей имеющих _ в названии,
например, group_id. Определим множественные фильтры по наличию в них
знака ".", например, person.id.