### PR TITLE
Поправка по получению активных приказов сотрудника

### DIFF
--- a/_core/_models/staff/CPerson.class.php
+++ b/_core/_models/staff/CPerson.class.php
@@ -677,7 +677,8 @@ class CPerson extends CActiveModel{
      */
     public function getActiveOrders() {
         $result = new CArrayList();
-        foreach ($this->orders->getItems() as $order) {
+        foreach (CActiveRecordProvider::getWithCondition(TABLE_STAFF_ORDERS, "kadri_id = ".$this->getId())->getItems() as $item) {
+            $order = new COrder($item);
             if ($order->isActive()) {
                 $result->add($order->getId(), $order);
             }


### PR DESCRIPTION
При массовом получении списка приказов для нескольких сотрудников
наблюдается попадание в список приказов приказа другого сотрудника
(только у некоторых сотрудников). При однократном вызове функции
getActiveOrders() для таких сотрудников с ошибочными приказами подобной
ошибки нет. Как решение, изменено получение списка приказов с помощью
запроса.